### PR TITLE
Add missing version bounds

### DIFF
--- a/canon.cabal
+++ b/canon.cabal
@@ -19,10 +19,10 @@ cabal-version:       >=1.10
 
 library
     build-depends       : base >= 4.9.1.0 && < 5
-                        , arithmoi >= 0.6.0.1 
+                        , arithmoi >= 0.6.0.1 && < 0.9
                         , array >= 0.5.1.1 && < 0.6
                         , containers >= 0.5.7.1 && < 0.7
-                        , random >= 1.0
+                        , random >= 1.0 && < 1.2
 
     exposed-modules     : Math.NumberTheory.Canon
                           Math.NumberTheory.Canon.Simple


### PR DESCRIPTION
As can be seen on

- https://matrix.hackage.haskell.org/package/canon@1559353919 

the current package metadata of the recent `canon-0.1.1.0` release allows the cabal solver to select unsound build-plans due to inaccurate/missing versions constraints on dependencies. Accurate version constraints are essential for providing Hackage users a good user experience.

Please note that uploading a new release will not be enough to address the issue at hand; instead a [Hackage metadata revision](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) is required to correct the inaccurate metadata of `canon-0.1.1.0`. You can do this easily yourself over at

- https://hackage.haskell.org/package/canon-0.1.1.0/canon.cabal/edit

or I can do it for you in my function as [Hackage Trustee](https://github.com/haskell-infra/hackage-trustees).

Please don't hesitate to let me know if you have any questions!